### PR TITLE
Fixes Nunjucks syntax for accessing _seoCanonical URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## UNRELEASED
+
+### Fixes
+
+* Fixes Nunjucks syntax for accessing _seoCanonical URL.
+
 ## 1.1.1 (2021-12-21)
 
 ### Adds

--- a/views/metaHead.html
+++ b/views/metaHead.html
@@ -29,7 +29,7 @@
 
 {# canonical URL #}
 {% if document._seoCanonical and document._seoCanonical.length  %}
-	<link rel="canonical" href="{{ document._seoCanonical._url }}" />
+	<link rel="canonical" href="{{ document._seoCanonical[0]._url }}" />
 {% endif %}
 
 {# Google Tracking ID #}


### PR DESCRIPTION
## Summary

*The original code is attempting to access a property that doesn't exist on the array object, the associated page reference is only accessible as the first item of the array.*

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [ ] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated