### PR TITLE
Canonical pieces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Adds
+- Canonical links for pieces, not only for pages from now on.
+
 ## 1.1.2 (2023-02-13)
 
 ### Changes
 - Remove `apostrophe` as a peer dependency.
-  
+
 ## 1.1.1 (2021-12-21)
 
 ### Adds

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -1,0 +1,5 @@
+{
+  "canonicalSelectType": "Kanonischer Typ für dieses Stück",
+  "canonicalModule": "{{ type }} Kanonischer Link",
+  "canonicalModuleHelp": "Gibt es eine Hauptversion dieses {{ type }}, auf die Suchmaschinen verweisen sollten?"
+}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -18,6 +18,7 @@
 
   "canonical": "Canonical Link",
   "canonicalHelp": "Is there a main version of this page that search engines should direct to?",
+  "canonicalSelectType": "Canonical type for this piece",
   "canonicalModule": "{{ type }} Canonical Link",
   "canonicalModuleHelp": "Is there a main version of this {{ type }} that search engines should direct to?"
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -17,5 +17,7 @@
   "googleVerifyIdHelp": "Verification ID provided by Google for the HTML meta tag verification option.",
 
   "canonical": "Canonical Link",
-  "canonicalHelp": "Is there a main version of this page that search engines should direct to?"
+  "canonicalHelp": "Is there a main version of this page that search engines should direct to?",
+  "canonicalModule": "{{ type }} Canonical Link",
+  "canonicalModuleHelp": "Is there a main version of this {{ type }} that search engines should direct to?"
 }

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -8,14 +8,17 @@
     "robotsNoFollow": "No leer (crawl) ligas en la página (nofollow)",
     "robotsNoIndex": "Dejar de indexar la página (noindex)",
     "group": "SEO",
-  
+
     "gtmId": "ID de Google Tag Manager",
     "gtmIdHelp": "ID del Contenedor proveído en el Google Tag Manager (e.g., GTM-RPCVDTN).",
     "gaId": "ID de Seguimiento de Google Analytics",
     "gaIdHelp": "ID de Seguimiento proveído por Google Analytics.",
     "googleVerifyId": "ID de Verificación de Google",
     "googleVerifyIdHelp": "ID de Verificación proveído por Google para la opción de verificación de la etiqueta meta del HTML.",
-  
+
     "canonical": "Liga o Enlace Canónico",
-    "canonicalHelp": "¿Hay una versión principal de esta página a donde los buscadores deberian dirigir a los usuarios?"
+    "canonicalHelp": "¿Hay una versión principal de esta página a donde los buscadores deberian dirigir a los usuarios?",
+    "canonicalSelectType": "Tipo canónico para esta pieza",
+    "canonicalModule": "{{ type }} Enlace Canónico",
+    "canonicalModuleHelp": "¿Hay una versión principal de este {{ tipo }} a la que deberían dirigirse los motores de búsqueda?"
   }

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -1,0 +1,5 @@
+{
+  "canonicalSelectType": "Type canonique pour cette pièce",
+  "canonicalModule": "Lien Canonique {{ type }}",
+  "canonicalModuleHelp": "Existe-t-il une version principale de {{ type }} vers laquelle les moteurs de recherche devraient se diriger ?"
+}

--- a/i18n/pt-BR.json
+++ b/i18n/pt-BR.json
@@ -1,0 +1,5 @@
+{
+  "canonicalSelectType": "Tipo canônico para esta peça",
+  "canonicalModule": "{{ type }} Link Canônico",
+  "canonicalModuleHelp": "Existe uma versão principal deste {{ type }} para a qual os mecanismos de pesquisa devem direcionar?"
+}

--- a/i18n/sk.json
+++ b/i18n/sk.json
@@ -15,5 +15,8 @@
   "googleVerifyId": "ID Overovací identifikátor Google",
   "googleVerifyIdHelp": "Verifikačné ID poskytnuté spoločnosťou Google pre možnosť overenia metaznačky HTML.",
   "canonical": "Kanonický odkaz",
-  "canonicalHelp": "Existuje hlavná verzia tejto stránky na ktorú by mali vyhľadávače smerovať?"
+  "canonicalHelp": "Existuje hlavná verzia tejto stránky na ktorú by mali vyhľadávače smerovať?",
+  "canonicalSelectType": "Kanonický typ pre tento kus",
+  "canonicalModule": "{{ type }} Kanonický Odkaz",
+  "canonicalModuleHelp": "Existuje hlavná verzia tohto {{ type }}, na ktorú by mali vyhľadávače smerovať?"
 }

--- a/modules/@apostrophecms/seo-fields-doc-type/index.js
+++ b/modules/@apostrophecms/seo-fields-doc-type/index.js
@@ -52,14 +52,17 @@ module.exports = {
         const req = options.apos.task.getReq();
         self.options.seoCanonicalTypes.forEach(canonicalType => {
           const name = canonicalType.startsWith('@apostrophecms/') ? canonicalType.split('@apostrophecms/')[1] : '';
+
           const fieldName = canonicalType.startsWith('@apostrophecms/')
             ? `_seoCanonical${_.kebabCase(name)}`
-            : `_seoCanonical${canonicalType}`;
-          const moduleName = options.apos.modules[canonicalType]
+            : `_seoCanonical${_.capitalize(canonicalType)}`;
+
+            const moduleName = options.apos.modules[canonicalType]
             ? options.apos.modules[canonicalType].label
             : name.replace(/-/, ' ');
+
           const label = req.t('aposSeo:canonicalModule', { type: _.startCase(req.t(moduleName) || canonicalType) });
-          const help = req.t('aposSeo:canonicalModuleHelp', { type: req.t(moduleName) || canonicalType });
+          const help = req.t('aposSeo:canonicalModuleHelp', { type: req.t(name) || canonicalType });
 
           configuration.add[fieldName] = {
             help,

--- a/modules/@apostrophecms/seo-fields-doc-type/index.js
+++ b/modules/@apostrophecms/seo-fields-doc-type/index.js
@@ -3,83 +3,88 @@ const _ = require('lodash');
 module.exports = {
   improve: '@apostrophecms/doc-type',
   fields(self, options) {
-    if (options.seoFields !== false) {
-      const configuration = {
-        add: {
-          seoTitle: {
-            label: 'aposSeo:title',
-            type: 'string',
-            htmlHelp: 'aposSeo:titleHtmlHelp'
-          },
-          seoDescription: {
-            label: 'aposSeo:description',
-            type: 'string',
-            htmlHelp: 'aposSeo:descriptionHtmlHelp'
-          },
-          seoRobots: {
-            label: 'aposSeo:robots',
-            htmlHelp: 'aposSeo:robotsHtmlHelp',
-            type: 'checkboxes',
-            choices: [
-              {
-                label: 'aposSeo:robotsNoFollow',
-                value: 'nofollow'
-              },
-              {
-                label: 'aposSeo:robotsNoIndex',
-                value: 'noindex'
-              }
-            ]
-          }
-        },
-        group: {
-          seo: {
-            label: 'aposSeo:group',
-            fields: [
-              'seoTitle',
-              'seoDescription',
-              'seoRobots'
-            ],
-            last: true
-          }
-        }
-      };
-
-      if (self.options.seoCanonicalTypes
-        && Array.isArray(self.options.seoCanonicalTypes)
-        && self.options.seoCanonicalTypes.length) {
-
-        const req = options.apos.task.getReq();
-
-        self.options.seoCanonicalTypes.forEach(canonicalType => {
-          const name = canonicalType.startsWith('@apostrophecms/') ? canonicalType.split('@apostrophecms/')[1] : canonicalType;
-          const fieldName = `_seoCanonical${_.capitalize(_.camelCase(name))}`;
-          const moduleName = options.apos.modules[canonicalType] && options.apos.modules[canonicalType].label
-            ? options.apos.modules[canonicalType].label
-            : name;
-          const label = req.t('aposSeo:canonicalModule', { type: _.startCase(req.t(moduleName)) });
-          const help = req.t('aposSeo:canonicalModuleHelp', { type: _.lowerCase(self.__meta.name) });
-
-          configuration.add[fieldName] = {
-            help,
-            label,
-            max: 1,
-            type: 'relationship',
-            withType: canonicalType,
-            builders: {
-              project: {
-                title: 1,
-                slug: 1,
-                _url: 1
-              }
-            }
-          };
-
-          configuration.group.seo.fields.push(fieldName);
-        });
-      }
-
-      return configuration;
+    if (!options.seoFields) {
+      return;
     }
+
+    const configuration = {
+      add: {
+        seoTitle: {
+          label: 'aposSeo:title',
+          type: 'string',
+          htmlHelp: 'aposSeo:titleHtmlHelp'
+        },
+        seoDescription: {
+          label: 'aposSeo:description',
+          type: 'string',
+          htmlHelp: 'aposSeo:descriptionHtmlHelp'
+        },
+        seoRobots: {
+          label: 'aposSeo:robots',
+          htmlHelp: 'aposSeo:robotsHtmlHelp',
+          type: 'checkboxes',
+          choices: [
+            {
+              label: 'aposSeo:robotsNoFollow',
+              value: 'nofollow'
+            },
+            {
+              label: 'aposSeo:robotsNoIndex',
+              value: 'noindex'
+            }
+          ]
+        }
+      },
+      group: {
+        seo: {
+          label: 'aposSeo:group',
+          fields: [
+            'seoTitle',
+            'seoDescription',
+            'seoRobots'
+          ],
+          last: true
+        }
+      }
+    };
+
+    if (self.options.seoCanonicalTypes &&
+        Array.isArray(self.options.seoCanonicalTypes) &&
+        self.options.seoCanonicalTypes.length) {
+
+      const req = options.apos.task.getReq();
+
+      self.options.seoCanonicalTypes.forEach(canonicalType => {
+        const name = canonicalType.startsWith('@apostrophecms')
+          ? canonicalType.startsWith('@apostrophecms-pro')
+            ? canonicalType.split('@apostrophecms-pro/')[1]
+            : canonicalType.split('@apostrophecms/')[1]
+          : canonicalType;
+
+        const fieldName = `_${_.camelCase(`seoCanonical ${name}`)}`;
+        const { label: moduleName = name } = options.apos.modules[canonicalType] || {};
+        const label = req.t('aposSeo:canonicalModule', { type: _.startCase(req.t(moduleName)) });
+        const help = req.t('aposSeo:canonicalModuleHelp', { type: _.lowerCase(self.__meta.name) });
+
+        configuration.add[fieldName] = {
+          help,
+          label,
+          max: 1,
+          type: 'relationship',
+          withType: canonicalType,
+          builders: {
+            project: {
+              title: 1,
+              slug: 1,
+              _url: 1
+            }
+          }
+        };
+
+        configuration.group.seo.fields.push(fieldName);
+      });
+    }
+
+    return configuration;
   }
 };

--- a/modules/@apostrophecms/seo-fields-doc-type/index.js
+++ b/modules/@apostrophecms/seo-fields-doc-type/index.js
@@ -50,19 +50,15 @@ module.exports = {
         && self.options.seoCanonicalTypes.length) {
 
         const req = options.apos.task.getReq();
+
         self.options.seoCanonicalTypes.forEach(canonicalType => {
-          const name = canonicalType.startsWith('@apostrophecms/') ? canonicalType.split('@apostrophecms/')[1] : '';
-
-          const fieldName = canonicalType.startsWith('@apostrophecms/')
-            ? `_seoCanonical${_.kebabCase(name)}`
-            : `_seoCanonical${_.capitalize(canonicalType)}`;
-
-            const moduleName = options.apos.modules[canonicalType]
+          const name = canonicalType.startsWith('@apostrophecms/') ? canonicalType.split('@apostrophecms/')[1] : canonicalType;
+          const fieldName = `_seoCanonical${_.capitalize(_.camelCase(name))}`;
+          const moduleName = options.apos.modules[canonicalType] && options.apos.modules[canonicalType].label
             ? options.apos.modules[canonicalType].label
-            : name.replace(/-/, ' ');
-
-          const label = req.t('aposSeo:canonicalModule', { type: _.startCase(req.t(moduleName) || canonicalType) });
-          const help = req.t('aposSeo:canonicalModuleHelp', { type: req.t(name) || canonicalType });
+            : name;
+          const label = req.t('aposSeo:canonicalModule', { type: _.startCase(req.t(moduleName)) });
+          const help = req.t('aposSeo:canonicalModuleHelp', { type: _.lowerCase(self.__meta.name) });
 
           configuration.add[fieldName] = {
             help,

--- a/modules/@apostrophecms/seo-fields-doc-type/index.js
+++ b/modules/@apostrophecms/seo-fields-doc-type/index.js
@@ -49,10 +49,18 @@ module.exports = {
     };
 
     if (self.options.seoCanonicalTypes &&
-        Array.isArray(self.options.seoCanonicalTypes) &&
-        self.options.seoCanonicalTypes.length) {
+      Array.isArray(self.options.seoCanonicalTypes) &&
+      self.options.seoCanonicalTypes.length) {
 
       const req = options.apos.task.getReq();
+      const choices = [];
+      configuration.add.seoSelectType = {
+        type: 'select',
+        label: req.t('aposSeo:canonicalSelectType'),
+        choices,
+        def: null
+      };
+      configuration.group.seo.fields.push('seoSelectType');
 
       self.options.seoCanonicalTypes.forEach(canonicalType => {
         const name = canonicalType.startsWith('@apostrophecms')
@@ -66,6 +74,10 @@ module.exports = {
         const label = req.t('aposSeo:canonicalModule', { type: _.startCase(req.t(moduleName)) });
         const help = req.t('aposSeo:canonicalModuleHelp', { type: _.lowerCase(self.__meta.name) });
 
+        choices.push({
+          label: _.startCase(req.t(moduleName)),
+          value: fieldName
+        });
         configuration.add[fieldName] = {
           help,
           label,
@@ -78,6 +90,9 @@ module.exports = {
               slug: 1,
               _url: 1
             }
+          },
+          if: {
+            seoSelectType: fieldName
           }
         };
 

--- a/modules/@apostrophecms/seo-fields-doc-type/index.js
+++ b/modules/@apostrophecms/seo-fields-doc-type/index.js
@@ -53,7 +53,7 @@ module.exports = {
         self.options.seoCanonicalTypes.forEach(canonicalType => {
           const name = canonicalType.startsWith('@apostrophecms/') ? canonicalType.split('@apostrophecms/')[1] : '';
           const fieldName = canonicalType.startsWith('@apostrophecms/')
-            ? `_${_.kebabCase(name)}`
+            ? `_seoCanonical${_.kebabCase(name)}`
             : `_seoCanonical${canonicalType}`;
           const moduleName = options.apos.modules[canonicalType]
             ? options.apos.modules[canonicalType].label

--- a/modules/@apostrophecms/seo-fields-doc-type/index.js
+++ b/modules/@apostrophecms/seo-fields-doc-type/index.js
@@ -59,7 +59,7 @@ module.exports = {
             ? options.apos.modules[canonicalType].label
             : name.replace(/-/, ' ');
           const label = req.t('aposSeo:canonicalModule', { type: _.startCase(req.t(moduleName) || canonicalType) });
-          const help = req.t('aposSeo:canonicalHelpModule', { type: req.t(moduleName) || canonicalType });
+          const help = req.t('aposSeo:canonicalModuleHelp', { type: req.t(moduleName) || canonicalType });
 
           configuration.add[fieldName] = {
             help,

--- a/modules/@apostrophecms/seo-fields-doc-type/index.js
+++ b/modules/@apostrophecms/seo-fields-doc-type/index.js
@@ -63,12 +63,7 @@ module.exports = {
       configuration.group.seo.fields.push('seoSelectType');
 
       self.options.seoCanonicalTypes.forEach(canonicalType => {
-        const name = canonicalType.startsWith('@apostrophecms')
-          ? canonicalType.startsWith('@apostrophecms-pro')
-            ? canonicalType.split('@apostrophecms-pro/')[1]
-            : canonicalType.split('@apostrophecms/')[1]
-          : canonicalType;
-
+        const name = canonicalType.split(/^apostrophecms\/|apostrophecms-pro\//)[1] || canonicalType;
         const fieldName = `_${_.camelCase(`seoCanonical ${name}`)}`;
         const { label: moduleName = name } = options.apos.modules[canonicalType] || {};
         const label = req.t('aposSeo:canonicalModule', { type: _.startCase(req.t(moduleName)) });

--- a/modules/@apostrophecms/seo-fields-doc-type/index.js
+++ b/modules/@apostrophecms/seo-fields-doc-type/index.js
@@ -1,8 +1,10 @@
+const _ = require('lodash');
+
 module.exports = {
   improve: '@apostrophecms/doc-type',
   fields(self, options) {
     if (options.seoFields !== false) {
-      return {
+      const configuration = {
         add: {
           seoTitle: {
             label: 'aposSeo:title',
@@ -42,6 +44,43 @@ module.exports = {
           }
         }
       };
+
+      if (self.options.seoCanonicalTypes
+        && Array.isArray(self.options.seoCanonicalTypes)
+        && self.options.seoCanonicalTypes.length) {
+
+        const req = options.apos.task.getReq();
+        self.options.seoCanonicalTypes.forEach(canonicalType => {
+          const name = canonicalType.startsWith('@apostrophecms/') ? canonicalType.split('@apostrophecms/')[1] : '';
+          const fieldName = canonicalType.startsWith('@apostrophecms/')
+            ? `_${_.kebabCase(name)}`
+            : `_seoCanonical${canonicalType}`;
+          const moduleName = options.apos.modules[canonicalType]
+            ? options.apos.modules[canonicalType].label
+            : name.replace(/-/, ' ');
+          const label = req.t('aposSeo:canonicalModule', { type: _.startCase(req.t(moduleName) || canonicalType) });
+          const help = req.t('aposSeo:canonicalHelpModule', { type: req.t(moduleName) || canonicalType });
+
+          configuration.add[fieldName] = {
+            help,
+            label,
+            max: 1,
+            type: 'relationship',
+            withType: canonicalType,
+            builders: {
+              project: {
+                title: 1,
+                slug: 1,
+                _url: 1
+              }
+            }
+          };
+
+          configuration.group.seo.fields.push(fieldName);
+        });
+      }
+
+      return configuration;
     }
   }
 };

--- a/views/metaHead.html
+++ b/views/metaHead.html
@@ -28,9 +28,13 @@
 {% endif %}
 
 {# canonical URL #}
-{% if document._seoCanonical and document._seoCanonical.length  %}
-	<link rel="canonical" href="{{ document._seoCanonical._url }}" />
-{% endif %}
+{% for name, items in document %}
+  {% if '_seoCanonical' in name %}
+    {% for item in items %}
+      <link rel="canonical" href="{{ item._url }}" />
+    {% endfor %}
+  {% endif %}
+{% endfor %}
 
 {# Google Tracking ID #}
 {% if global.seoGoogleTrackingId %}

--- a/views/metaHead.html
+++ b/views/metaHead.html
@@ -27,14 +27,13 @@
   <meta name="google-site-verification" content="{{ global.seoGoogleVerificationId }}" />
 {% endif %}
 
-{# canonical URL #}
-{% for name, items in document %}
-  {% if '_seoCanonical' in name %}
-    {% for item in items %}
-      <link rel="canonical" href="{{ item._url }}" />
-    {% endfor %}
-  {% endif %}
-{% endfor %}
+{% if document._seoCanonical and document._seoCanonical.length %}
+  {# canonical page URL #}
+  <link rel="canonical" href="{{ document._seoCanonical[0]._url }}" />
+{% elif document.seoSelectType and document[document.seoSelectType] and document[document.seoSelectType].length %}
+  {# canonical piece-page URL #}
+  <link rel="canonical" href="{{ document[document.seoSelectType][0]._url }}" />
+{% endif %}
 
 {# Google Tracking ID #}
 {% if global.seoGoogleTrackingId %}


### PR DESCRIPTION
https://linear.app/apostrophecms/issue/PRO-3824/add-canonicals-to-pieces-so-that-this-seo-function-is-consistent

Add canonicals to pieces so that this SEO function is consistent across page and pieces, improving search results.

## How to test

- Link project to testbed
- Add a `seoCanonicalTypes` configuration to a module. For instance, in `modules/articles/article/index.js` options object: `seoCanonicalTypes: [ 'topic', '@apostrophecms/page' ]`
- Check matching fields are defined in the "SEO" tab and can save canonical
- Check link tag is generated in the `head` tag in article's page (need to create an article index page, and a topic index page if following my example here)

<img width="1010" alt="image" src="https://user-images.githubusercontent.com/11479686/224668910-79f7cfde-055b-4b81-a6dc-4a86e7d112f2.png">

<img width="626" alt="image" src="https://user-images.githubusercontent.com/11479686/224669801-64f66cac-6a5e-4da4-8819-26b5f9af3ee4.png">

